### PR TITLE
removed errant quote in date YAML key for post archetype

### DIFF
--- a/R/site-academic.R
+++ b/R/site-academic.R
@@ -117,7 +117,7 @@ academic_patch_post_archetype <- function(path) {
     'title: "{{ title }}"',
     fixed = TRUE
   )
-  lines <- line_replace(lines, 'date: {{ .Date }}', 'date: {{ date }}"', fixed = TRUE)
+  lines <- line_replace(lines, 'date: {{ .Date }}', 'date: {{ date }}', fixed = TRUE)
   lines <- line_replace(lines, 'lastmod: {{ .Date }}', 'lastmod: {{ date }}', fixed = TRUE)
 
   brio::write_lines(lines, path)


### PR DESCRIPTION
Fixes this:

<img width="1188" alt="Screen Shot 2020-06-09 at 4 13 16 PM" src="https://user-images.githubusercontent.com/12160301/84209897-290b0780-aa6c-11ea-90fa-96f81309935f.png">
