### PR TITLE
workaround for shortcodes?

### DIFF
--- a/tests/testthat/shortcode.Rmd
+++ b/tests/testthat/shortcode.Rmd
@@ -1,0 +1,7 @@
+---
+output: hugodown::md_document
+---
+
+```{=html}
+{{< figure src="blabla.png" >}}
+```

--- a/tests/testthat/test-md-document.R
+++ b/tests/testthat/test-md-document.R
@@ -50,6 +50,11 @@ test_that("emojis are preserved", {
   expect_equal(rmd$lines[[7]], ":smile_cat:")
 })
 
+test_that("shortcodes are preserved", {
+  rmd <- local_render(test_path("shortcode.Rmd"))
+  expect_equal(rmd$lines[[7]], '{{< figure src="blabla.png" >}}')
+})
+
 test_that("math is untransformed", {
   rmd <- local_render(test_path("math.Rmd"))
   expect_equal(rmd$lines[[7]], "$a_1 + b_2$")


### PR DESCRIPTION
Using [pandoc raw attributes](https://pandoc.org/MANUAL.html#extension-raw_attribute)

I now feel guilty using shortcodes in hugodown Rmd but I've just found how to escape them. :smiling_imp:  Would it be worth documenting in a footnote somewhere or is it best kept as a secret tip among the Hugo rebels? (the test is a POC, not a test) cc @jemus42 @apreshill 

FWIW for things like embedding tweets I agree R might do a better job with safe failures.