### PR TITLE
Code chunks other than R rendered as NA

### DIFF
--- a/R/md-document.R
+++ b/R/md-document.R
@@ -240,13 +240,13 @@ knit_hooks <- function() {
       needs_code(FALSE, x)
     } else {
       x <- paste0(x, "\n", collapse = "")
-      x <- highlight_if_possible(x)
+      if (options$engine == "R") x <- highlight_if_possible(x)
       needs_code(TRUE, x)
     }
   }
   hook_source <- function(x, options) {
     x <- paste0(x, "\n", collapse = "")
-    x <- highlight_if_possible(x)
+    if (options$engine == "R") x <- highlight_if_possible(x)
     x <- paste0(x, "\n")
     needs_code(TRUE, x)
   }

--- a/R/md-document.R
+++ b/R/md-document.R
@@ -229,16 +229,6 @@ knit_hooks <- function() {
     }
   }
 
-  # if x is not valid R code, downlit::highlight will return NA
-  # In this case, we return x without highlighting.
-  highlight_if_possible <- function(x, engine) {
-    if (engine != "R") {
-      x
-    } else {
-      x_highlighted <- downlit::highlight(x, pre_class = NULL)
-      if (is.na(x_highlighted)) x else x_highlighted
-    }
-  }
   hook_output <- function(type, x, options) {
     if (options$results == "asis") {
       needs_code(FALSE, x)
@@ -289,6 +279,21 @@ knit_hooks <- function() {
     error   = function(x, opts) hook_output("error", x, opts),
     message = function(x, opts) hook_output("message", x, opts)
   )
+}
+
+# if x is not valid R code, downlit::highlight will return NA
+# In this case, we return x without highlighting.
+highlight_if_possible <- function(x, engine) {
+  if (engine != "R") {
+    x
+  } else {
+    out <- downlit::highlight(x, pre_class = NULL)
+    if (is.na(out)) {
+      x
+    } else {
+      out
+    }
+  }
 }
 
 

--- a/R/md-document.R
+++ b/R/md-document.R
@@ -229,18 +229,24 @@ knit_hooks <- function() {
     }
   }
 
+  # if x is not valid R code, downlit::highlight will return NA
+  # In this case, we return x without highlighting.
+  highlight_if_possible <- function(x) {
+    x_highlighted <- downlit::highlight(x, pre_class = NULL)
+    if (is.na(x_highlighted)) x else x_highlighted
+  }
   hook_output <- function(type, x, options) {
     if (options$results == "asis") {
       needs_code(FALSE, x)
     } else {
       x <- paste0(x, "\n", collapse = "")
-      x <- downlit::highlight(x, pre_class = NULL)
+      x <- highlight_if_possible(x)
       needs_code(TRUE, x)
     }
   }
   hook_source <- function(x, options) {
     x <- paste0(x, "\n", collapse = "")
-    x <- downlit::highlight(x, pre_class = NULL)
+    x <- highlight_if_possible(x)
     x <- paste0(x, "\n")
     needs_code(TRUE, x)
   }

--- a/R/md-document.R
+++ b/R/md-document.R
@@ -231,22 +231,26 @@ knit_hooks <- function() {
 
   # if x is not valid R code, downlit::highlight will return NA
   # In this case, we return x without highlighting.
-  highlight_if_possible <- function(x) {
-    x_highlighted <- downlit::highlight(x, pre_class = NULL)
-    if (is.na(x_highlighted)) x else x_highlighted
+  highlight_if_possible <- function(x, engine) {
+    if (engine != "R") {
+      x
+    } else {
+      x_highlighted <- downlit::highlight(x, pre_class = NULL)
+      if (is.na(x_highlighted)) x else x_highlighted
+    }
   }
   hook_output <- function(type, x, options) {
     if (options$results == "asis") {
       needs_code(FALSE, x)
     } else {
       x <- paste0(x, "\n", collapse = "")
-      if (options$engine == "R") x <- highlight_if_possible(x)
+      x <- highlight_if_possible(x, options$engine)
       needs_code(TRUE, x)
     }
   }
   hook_source <- function(x, options) {
     x <- paste0(x, "\n", collapse = "")
-    if (options$engine == "R") x <- highlight_if_possible(x)
+    x <- highlight_if_possible(x, options$engine)
     x <- paste0(x, "\n")
     needs_code(TRUE, x)
   }

--- a/tests/testthat/code-invalid.Rmd
+++ b/tests/testthat/code-invalid.Rmd
@@ -1,0 +1,7 @@
+---
+output: hugodown::md_document
+---
+
+```{r, eval = FALSE}
+1 + 
+```

--- a/tests/testthat/test-md-document.R
+++ b/tests/testthat/test-md-document.R
@@ -27,6 +27,11 @@ test_that("code is linked/highlighted", {
   expect_equal(sum(grepl("[`stats::median()`]", rmd$lines, fixed = TRUE)), 1)
 })
 
+test_that("unparseable code is left as is", {
+  rmd <- local_render(test_path("code-invalid.Rmd"))
+  expect_match(rmd$lines[9], "1 + ", fixed = TRUE)
+})
+
 test_that("output gets unicode and colour", {
   skip_on_os("windows")
 


### PR DESCRIPTION
Fixes #58 
I've fixed this in two ways:

* If the engine for the chunk is not R, don't attempt to apply the `downlit::highlight()` function. This fixes the issue whereby non-R code chunks are rendered as `NA`, since `downlit::highlight()` doesn't recognise them as valid R code.
* If the engine is R, but `downlit::highlight()` returns `NA`, then don't apply `downlit::highlight()`. This fixes the issue whereby code chunks with invalid R code are rendered as `NA`. An example where this might occur is a code chunk with `eval = FALSE` containing a function without a body, eg. `y <- function(x)`.

Even though chunk outputs didn't seem to be affected by the issue, I've included the changes in `hook_output` as well as `hook_source`. Unsure if this is correct, but I can't think of a reason against it.