### PR TITLE
Add missing command in netlify.toml

### DIFF
--- a/inst/templates/netlify.toml
+++ b/inst/templates/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  command = "hugo -d public"
+  command = "hugo"
 
 [build.environment]
   HUGO_VERSION = "{{hugo_version}}"

--- a/inst/templates/netlify.toml
+++ b/inst/templates/netlify.toml
@@ -1,5 +1,6 @@
 [build]
   publish = "public"
+  command = "hugo -d public"
 
 [build.environment]
   HUGO_VERSION = "{{hugo_version}}"


### PR DESCRIPTION
@hadley without this command one cannot use the Netlify config for the production build (I've just had the problem).