### PR TITLE
Add commonmark extensions for goldmark_format

### DIFF
--- a/R/md-document.R
+++ b/R/md-document.R
@@ -140,25 +140,27 @@ md_document <- function(fig_width = 7,
   )
 }
 
-# https://github.com/rstudio/rstudio/blob/master/src/gwt/panmirror/src/editor/src/api/pandoc_format.ts#L335-L359
 goldmark_format <- function() {
   paste(
     "markdown_strict",
-    'all_symbols_escapable',
-    'fenced_code_blocks',
-    'space_in_atx_header',
-    'intraword_underscores',
-    'lists_without_preceding_blankline',
-    'shortcut_reference_links',
+    # https://github.com/rstudio/rstudio/blob/master/src/gwt/panmirror/src/editor/src/api/pandoc_format.ts#L344-L356
+    "all_symbols_escapable",
+    "backtick_code_blocks",
+    "fenced_code_blocks",
+    "space_in_atx_header",
+    "intraword_underscores",
+    "lists_without_preceding_blankline",
+    "shortcut_reference_links",
+    # https://github.com/rstudio/rstudio/blob/master/src/gwt/panmirror/src/editor/src/api/pandoc_format.ts#L380-L392
     "pipe_tables",
     "strikeout",
     "autolink_bare_uris",
     "task_lists",
-    "backtick_code_blocks",
     "definition_lists",
     "footnotes",
     "smart",
     "tex_math_dollars",
+    # custom
     "native_divs",
     "emoji",
     sep = "+"

--- a/R/md-document.R
+++ b/R/md-document.R
@@ -144,6 +144,12 @@ md_document <- function(fig_width = 7,
 goldmark_format <- function() {
   paste(
     "markdown_strict",
+    'all_symbols_escapable',
+    'fenced_code_blocks',
+    'space_in_atx_header',
+    'intraword_underscores',
+    'lists_without_preceding_blankline',
+    'shortcut_reference_links',
     "pipe_tables",
     "strikeout",
     "autolink_bare_uris",


### PR DESCRIPTION
Since goldmark is based on commonmark (unlike blackfriday which isn't), we need to add all base commonmark extensions to markdown_strict.

Note that there are a couple of test failures in tests/testthat/test-md-document-hooks.txt. I don't believe thesre are actual failures but rather a result in changes in how pandoc generates markdown: (1) The underscore change is from the inclusion of `intraword_underscores`; (2) The table change is a result of a underlying change in how pandoc generates aligned table cells.