### PR TITLE
increases hugo_start() timeout length

### DIFF
--- a/R/hugo-server.R
+++ b/R/hugo-server.R
@@ -16,6 +16,8 @@
 #' `hugo_start()` starts a hugo server that will automatically re-generate
 #' the site whenever the input changes. You only need to execute this once
 #' per session; it continues to run in the background as you work on the site.
+#' For large sites the hugo server can be slow to start; if it takes longer
+#' than 30 seconds `hugo_start()` throws an error.
 #'
 #' `hugo_stop()` kills the server. This happens automatically when you exit
 #' R so you shouldn't normally need to run this.
@@ -60,7 +62,7 @@ hugo_start <- function(site = ".",
   now <- proc.time()[[3]]
   ok <- FALSE
 
-  while (proc.time()[[3]] - now < 5) {
+  while (proc.time()[[3]] - now < 30) {
     ps$poll_io(250)
     init <- paste0(init, ps$read_output())
 

--- a/man/hugo_start.Rd
+++ b/man/hugo_start.Rd
@@ -35,6 +35,8 @@ site from memory, but rendering to disk can be helpful for debugging.}
 \code{hugo_start()} starts a hugo server that will automatically re-generate
 the site whenever the input changes. You only need to execute this once
 per session; it continues to run in the background as you work on the site.
+For large sites the hugo server can be slow to start; if it takes longer
+than 30 seconds \code{hugo_start()} throws an error.
 
 \code{hugo_stop()} kills the server. This happens automatically when you exit
 R so you shouldn't normally need to run this.


### PR DESCRIPTION
Increases the timeout length for `hugo_start()` to 30 seconds and briefly documents this behaviour. Verified that this fixes #80 for the website mentioned in the issue.