### PR TITLE
fix path for academic files

### DIFF
--- a/R/site-academic.R
+++ b/R/site-academic.R
@@ -56,7 +56,6 @@ academic_download <- function(version = "4.8.0") {
   )
   exdir <- file_temp("hugodown")
   utils::unzip(zip, exdir = exdir)
-
   path(exdir, paste0("wowchemy-hugo-modules-", version))
 }
 

--- a/R/site-academic.R
+++ b/R/site-academic.R
@@ -51,7 +51,7 @@ create_site_academic <- function(
 
 academic_download <- function(version = "4.8.0") {
   zip <- curl::curl_download(
-    paste0("https://github.com/gcushen/hugo-academic/archive/v", version, ".zip"),
+    paste0("https://github.com/wowchemy/wowchemy-hugo-modules/archive/v", version, ".zip"),
     file_temp("hugodown")
   )
   exdir <- file_temp("hugodown")

--- a/R/site-academic.R
+++ b/R/site-academic.R
@@ -56,7 +56,8 @@ academic_download <- function(version = "4.8.0") {
   )
   exdir <- file_temp("hugodown")
   utils::unzip(zip, exdir = exdir)
-  path(exdir, paste0("hugo-academic-", version))
+
+  path(exdir, paste0("wowchemy-hugo-modules-", version))
 }
 
 academic_install <- function(path, theme_dir) {


### PR DESCRIPTION
@hadley the academic repo moved/change structures (see https://github.com/rstudio/blogdown/commit/04f71b579dd6199eb7189b879ffd1c785f58fde6 in blogdown).

With this tweak I can use `create_site_academic()` again. I was just checking my hugodown demo still worked for LatinR next week, that was scary :joy: