### PR TITLE
Drop brackets from YAML example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ devtools::install_github("r-lib/hugodown")
 
 ## Usage
 
-The key to using hugodown is to put `output: hugodown::md_document()` in the YAML metadata of your `.Rmd` files. Then knitting the file will generate a `.md` file designed to work well with hugo. The rest of hugodown just makes your life a little easier:
+The key to using hugodown is to put `output: hugodown::md_document` in the YAML metadata of your `.Rmd` files. Then knitting the file will generate a `.md` file designed to work well with hugo. The rest of hugodown just makes your life a little easier:
 
 * `hugo_start()` will automatically start a hugo server in the background,
   automatically previewing your site as you update it.


### PR DESCRIPTION
I seemed to find I needed to drop these brackets, changing

```output: hugodown::md_document()```

to

```output: hugodown::md_document```

Apologies if I am misunderstanding!