### PR TITLE
Bring back other newline removed in #92

### DIFF
--- a/R/md-document.R
+++ b/R/md-document.R
@@ -243,7 +243,7 @@ knit_hooks <- function() {
     if (options$results == "asis") {
       needs_code(FALSE, x)
     } else {
-      x <- paste0(x, collapse = "")
+      x <- paste0(x, "\n", collapse = "")
       x <- highlight_if_possible(x, options$engine)
       needs_code(TRUE, x)
     }

--- a/tests/testthat/_snaps/md-document.md
+++ b/tests/testthat/_snaps/md-document.md
@@ -13,7 +13,8 @@
     <pre class='chroma'><code class='language-r' data-lang='r'><span><span class='nv'>df</span> <span class='o'>&lt;-</span> <span class='nf'><a href='https://rdrr.io/r/base/data.frame.html'>data.frame</a></span><span class='o'>(</span>x <span class='o'>=</span> <span class='m'>1</span><span class='o'>)</span></span>
     <span><span class='nv'>df</span></span>
     <span><span class='c'>#&gt;   x</span></span>
-    <span><span class='c'>#&gt; 1 1</span></span><span></span>
+    <span><span class='c'>#&gt; 1 1</span></span>
+    <span></span><span></span>
     <span><span class='nf'>knitr</span><span class='nf'>::</span><span class='nf'><a href='https://rdrr.io/pkg/knitr/man/kable.html'>kable</a></span><span class='o'>(</span><span class='nv'>df</span><span class='o'>)</span></span>
     </code></pre>
     
@@ -29,9 +30,12 @@
     
     <pre class='chroma'><code class='language-r' data-lang='r'><span><span class='c'># comment</span></span>
     <span><span class='nf'><a href='https://rdrr.io/r/base/print.html'>print</a></span><span class='o'>(</span><span class='s'>"print"</span><span class='o'>)</span></span>
-    <span><span class='c'>#&gt; [1] "print"</span></span><span><span class='nf'><a href='https://rdrr.io/r/base/message.html'>message</a></span><span class='o'>(</span><span class='s'>"message"</span><span class='o'>)</span></span>
-    <span><span class='c'>#&gt; message</span></span><span><span class='kr'><a href='https://rdrr.io/r/base/warning.html'>warning</a></span><span class='o'>(</span><span class='s'>"warning"</span><span class='o'>)</span></span>
-    <span><span class='c'>#&gt; Warning: warning</span></span></code></pre>
+    <span><span class='c'>#&gt; [1] "print"</span></span>
+    <span></span><span><span class='nf'><a href='https://rdrr.io/r/base/message.html'>message</a></span><span class='o'>(</span><span class='s'>"message"</span><span class='o'>)</span></span>
+    <span><span class='c'>#&gt; message</span></span>
+    <span></span><span><span class='kr'><a href='https://rdrr.io/r/base/warning.html'>warning</a></span><span class='o'>(</span><span class='s'>"warning"</span><span class='o'>)</span></span>
+    <span><span class='c'>#&gt; Warning: warning</span></span>
+    <span></span></code></pre>
     
     </div>
     

--- a/tests/testthat/test-md-document.R
+++ b/tests/testthat/test-md-document.R
@@ -25,7 +25,7 @@ test_that("code is linked/highlighted", {
 
   expect_equal(
     xpath_text(rmd$xml, "(//pre)[1]"),
-    "1 + 1\n#> [1] 2"
+    "1 + 1\n#> [1] 2\n"
   )
 
   expect_equal(sum(grepl("<pre", rmd$lines, fixed = TRUE)), 2)
@@ -44,7 +44,7 @@ test_that("output gets unicode and colour", {
   code <- xpath_xml(rmd$xml, "//pre//code/span")
 
   expect_equal(xpath_attr(code[[1]], "./span/span", "style"), "color: #0000BB;")
-  expect_equal(xpath_text(code[[2]], "."), "#> \u2714")
+  expect_equal(xpath_text(code[[3]], "."), "#> \u2714")
 })
 
 test_that("interweaving of code and output generates correct html", {


### PR DESCRIPTION
#92 removed two newlines

After https://github.com/r-lib/hugodown/issues/106 was reported, https://github.com/r-lib/hugodown/pull/108 restored one of the two.

But when I render with `main` hugodown, I am now seeing that we don't have _enough_ newlines, and it seems like restoring the other one that was removed fixes it. I do not understand why.

I also rendered the usethis 2.0.0 post with this PR installed, and I don't see the double new line that was present in @jennybc's image here after `git_protocol()`, so idk what changed but it was probably pandoc or knitr? https://github.com/r-lib/hugodown/issues/91#issue-796266452

<img width="1463" alt="Screen Shot 2022-11-23 at 12 13 01 PM" src="https://user-images.githubusercontent.com/19150088/203614505-05e68ac1-947e-4524-b498-c0184e725809.png">
<img width="1482" alt="Screen Shot 2022-11-23 at 12 13 24 PM" src="https://user-images.githubusercontent.com/19150088/203614508-ba3e681c-af82-430b-a4d4-2e76b762d66b.png">
